### PR TITLE
Set WebSocket host

### DIFF
--- a/lib/util/api.js
+++ b/lib/util/api.js
@@ -18,7 +18,7 @@ if (fs.existsSync(configPath) && fs.existsSync(apiTokenPath)) {
 if (fs.existsSync(configPath) && fs.existsSync(hostPath)) {
   host = fs.readFileSync(path.join(configPath, 'host'));
 } else {
-	host = 'http://localhost:3000';
+    host = 'http://localhost:3000';
 }
 
 const wsProtocol = host.toString().startsWith('https:') ? 'wss:' : 'ws:';

--- a/lib/util/api.js
+++ b/lib/util/api.js
@@ -6,8 +6,10 @@ const axios = require('axios').default;
 const configPath = path.join(homedir, '.mothership-cli');
 const apiTokenPath = path.join(configPath, 'apiToken');
 const hostPath = path.join(configPath, 'host');
+const url = require('url');
 let apiToken;
 let host;
+let wsHost;
 
 if (fs.existsSync(configPath) && fs.existsSync(apiTokenPath)) {
   apiToken = fs.readFileSync(path.join(configPath, 'apiToken'));
@@ -19,6 +21,10 @@ if (fs.existsSync(configPath) && fs.existsSync(hostPath)) {
 	host = 'http://localhost:3000';
 }
 
+const wsProtocol = host.toString().startsWith('https:') ? 'wss:' : 'ws:';
+const mothershipHost = url.parse(host.toString()).host;
+wsHost = `${wsProtocol}//${mothershipHost}`;
+
 axios.defaults.headers.common['Accept'] = 'application/json';
 axios.defaults.headers.common['Authorization'] = `Bearer ${apiToken}`;
 
@@ -29,7 +35,7 @@ const apiErrorHandler = (error) => {
 
 module.exports = {
   HOST: host,
-  WS_HOST: 'ws://localhost:3000',
+  WS_HOST: wsHost,
   apiToken: apiToken.toString(),
   api: axios,
   apiErrorHandler: apiErrorHandler,


### PR DESCRIPTION
* This PR sets the WS host based on the primary host the user is logged into.
  * The protocol for the WS host is based on whether the host the user is logged into is `http` or `https` (thus, the WS protocol becomes either `ws` or `wss`).
  * Previously we were simply using `localhost` for the WS host.